### PR TITLE
FIX Ensure source_file_comments works without throwing errors

### DIFF
--- a/src/SSTemplateParser.peg
+++ b/src/SSTemplateParser.peg
@@ -1308,9 +1308,11 @@ EOC;
     protected function includeDebuggingComments(string $code, string $templateName): string
     {
         // If this template contains a doctype, put it right after it,
-        // if not, put it after the <html> tag to avoid IE glitches
-        if (stripos($code ?? '', "<!doctype") !== false) {
-            $code = preg_replace('/(<!doctype[^>]*("[^"]")*[^>]*>)/im', "$1\r\n<!-- template $templateName -->", $code ?? '');
+        // if not, put it after the <html> tag to avoid IE glitches.
+        // Some cached templates will have a preg_match looking for the doctype, so we use a
+        // negative lookbehind to exclude that from our matches.
+        if (preg_match('/(?<!preg_match\(\'\/)<!doctype/i', $code)) {
+            $code = preg_replace('/((?<!preg_match\(\'\/)<!doctype[^>]*("[^"]")*[^>]*>)/im', "$1\r\n<!-- template $templateName -->", $code ?? '');
             $code .= "\r\n" . '$val .= \'<!-- end template ' . $templateName . ' -->\';';
         } elseif (stripos($code ?? '', "<html") !== false) {
             $code = preg_replace_callback('/(.*)(<html[^>]*>)(.*)/i', function ($matches) use ($templateName) {

--- a/src/SSTemplateParser.php
+++ b/src/SSTemplateParser.php
@@ -5342,9 +5342,11 @@ EOC;
     protected function includeDebuggingComments(string $code, string $templateName): string
     {
         // If this template contains a doctype, put it right after it,
-        // if not, put it after the <html> tag to avoid IE glitches
-        if (stripos($code ?? '', "<!doctype") !== false) {
-            $code = preg_replace('/(<!doctype[^>]*("[^"]")*[^>]*>)/im', "$1\r\n<!-- template $templateName -->", $code ?? '');
+        // if not, put it after the <html> tag to avoid IE glitches.
+        // Some cached templates will have a preg_match looking for the doctype, so we use a
+        // negative lookbehind to exclude that from our matches.
+        if (preg_match('/(?<!preg_match\(\'\/)<!doctype/i', $code)) {
+            $code = preg_replace('/((?<!preg_match\(\'\/)<!doctype[^>]*("[^"]")*[^>]*>)/im', "$1\r\n<!-- template $templateName -->", $code ?? '');
             $code .= "\r\n" . '$val .= \'<!-- end template ' . $templateName . ' -->\';';
         } elseif (stripos($code ?? '', "<html") !== false) {
             $code = preg_replace_callback('/(.*)(<html[^>]*>)(.*)/i', function ($matches) use ($templateName) {


### PR DESCRIPTION
Base templates now include some regex to check the doctype, so the correct `<base>` tag can be used.

The code that checks for doctype in `includeDebuggingComments()` is (understandably) very naive and didn't account for the new regex. Now it does.

## Issue
- https://github.com/silverstripe/silverstripe-template-engine/issues/4