### PR TITLE
MNT Add readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+## Silverstripe Template Engine
+
+[![CI](https://github.com/silverstripe/silverstripe-template-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/silverstripe/silverstripe-template-engine/actions/workflows/ci.yml)
+[![Silverstripe supported module](https://img.shields.io/badge/silverstripe-supported-0071C4.svg)](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/)
+
+## Overview
+
+Provides a template engine for rendering `.ss` templates in Silverstripe CMS projects
+
+## Installation
+
+```sh
+composer require silverstripe/template-engine
+```
+
+## Documentation
+
+See [docs.silverstripe.org](https://docs.silverstripe.org/en/developer_guides/templates/)


### PR DESCRIPTION
Realised this repo was also missing a readme. Seemed sensible to just tack onto the existing issue since it's such a small thing.

## Issue
- https://github.com/silverstripe/silverstripe-htmleditor-tinymce/issues/7