### PR TITLE
FIX Don't rewrite hash links - let SSViewer handle that.

### DIFF
--- a/src/SSTemplateParser.peg
+++ b/src/SSTemplateParser.peg
@@ -1148,20 +1148,6 @@ class SSTemplateParser extends Parser implements TemplateParser
         $text = stripslashes($text ?? '');
         $text = addcslashes($text ?? '', '\'\\');
 
-        // TODO: This is pretty ugly & gets applied on all files not just html. I wonder if we can make this
-        // non-dynamically calculated
-        $code = <<<'EOC'
-(\SilverStripe\View\SSViewer::getRewriteHashLinksDefault()
-    ? \SilverStripe\Core\Convert::raw2att( preg_replace("/^(\\/)+/", "/", $_SERVER['REQUEST_URI'] ) )
-    : "")
-EOC;
-        // Because preg_replace replacement requires escaped slashes, addcslashes here
-        $text = preg_replace(
-            '/(<a[^>]+href *= *)"#/i',
-            '\\1"\' . ' . addcslashes($code ?? '', '\\')  . ' . \'#',
-            $text ?? ''
-        );
-
         $res['php'] .= '$val .= \'' . $text . '\';' . PHP_EOL;
     }
 

--- a/src/SSTemplateParser.php
+++ b/src/SSTemplateParser.php
@@ -4903,20 +4903,6 @@ class SSTemplateParser extends Parser implements TemplateParser
         $text = stripslashes($text ?? '');
         $text = addcslashes($text ?? '', '\'\\');
 
-        // TODO: This is pretty ugly & gets applied on all files not just html. I wonder if we can make this
-        // non-dynamically calculated
-        $code = <<<'EOC'
-(\SilverStripe\View\SSViewer::getRewriteHashLinksDefault()
-    ? \SilverStripe\Core\Convert::raw2att( preg_replace("/^(\\/)+/", "/", $_SERVER['REQUEST_URI'] ) )
-    : "")
-EOC;
-        // Because preg_replace replacement requires escaped slashes, addcslashes here
-        $text = preg_replace(
-            '/(<a[^>]+href *= *)"#/i',
-            '\\1"\' . ' . addcslashes($code ?? '', '\\')  . ' . \'#',
-            $text ?? ''
-        );
-
         $res['php'] .= '$val .= \'' . $text . '\';' . PHP_EOL;
     }
 


### PR DESCRIPTION
This rewriting is already done in `SSViewer`, so the template engine explicitly _should not_ be doing it.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11666