### PR TITLE
POC ONLY - live preview updates.

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,17 @@
+---
+Name: template-engine-js
+---
+SilverStripe\Admin\LeftAndMain:
+  extra_requirements_javascript:
+    - silverstripe/template-engine:client/dist/cms-to-iframe.js
+
+---
+Name: template-engine-middleware
+After:
+  - requestprocessors
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Control\Director:
+    properties:
+      Middlewares:
+        CustomMiddleware: '%$SilverStripe\TemplateEngine\Middleware\CMSPreviewMiddleware'

--- a/client/dist/cms-to-iframe.js
+++ b/client/dist/cms-to-iframe.js
@@ -1,0 +1,26 @@
+
+jQuery.entwine('ss-template', function($) {
+
+  /**
+   * When we update values, tell the iframe what we updated.
+   * Caveats:
+   * 1. Obviously react fields aren't included. NO idea how we're gonna handle that gracefully.
+   *
+   */
+  $('input,textarea').entwine({
+    onchange: function(event) {
+      console.log({inHost: event});
+      if ($('iframe[name="cms-preview-iframe"]').length !== 0) {
+        const msg = {
+          className: document.querySelector('[name="ClassName"]').value,
+          id: document.querySelector('[name="ID"]').value,
+          field: this.attr('name'),
+          value: this.val(),
+        };
+        console.log(msg); // debugging
+        $('iframe[name="cms-preview-iframe"]')[0].contentWindow.postMessage(msg, "*");
+      }
+    },
+  });
+
+});

--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,10 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
+    },
+    "extra": {
+        "expose": [
+            "client/dist"
+        ]
     }
 }

--- a/src/Middleware/CMSPreviewMiddleware.php
+++ b/src/Middleware/CMSPreviewMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\TemplateEngine\Middleware;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Middleware\HTTPMiddleware;
+use SilverStripe\Security\Permission;
+
+class CMSPreviewMiddleware implements HTTPMiddleware
+{
+    private static bool $isCmsPreview = false;
+
+    public function process(HTTPRequest $request, callable $delegate)
+    {
+        if ($request->getVar('CMSPreview')) {
+            self::$isCmsPreview = true;
+        }
+        return $delegate($request);
+    }
+
+    public static function isCmsPreview(): bool
+    {
+        return self::$isCmsPreview && Permission::check('CMS_ACCESS');
+    }
+}

--- a/src/SSTemplateEngine.php
+++ b/src/SSTemplateEngine.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\TemplateEngine;
 
 use InvalidArgumentException;
+use Masterminds\HTML5;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Configurable;
@@ -13,6 +14,7 @@ use SilverStripe\Core\Kernel;
 use SilverStripe\Core\Path;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Security\Permission;
+use SilverStripe\TemplateEngine\Middleware\CMSPreviewMiddleware;
 use SilverStripe\View\Exception\MissingTemplateException;
 use SilverStripe\View\SSViewer;
 use SilverStripe\View\TemplateEngine;
@@ -243,6 +245,154 @@ class SSTemplateEngine implements TemplateEngine, Flushable
         }
 
         $output = $this->includeGeneratedTemplate($cacheFile, $model, $overlay, $underlay, $scope);
+
+        if (CMSPreviewMiddleware::isCmsPreview()) {
+            // Remove the nasty comments inside elements.
+            // @TODO This is a really awfully bad nasty way to remove the comments from attributes... It'll do for now.
+            //       The main downsides to this approach are:
+            //          1. It messes with the output - notably it excludes the <!DOCTYPE html> tag for some reason.
+            //          2. It means we can't use the template rendered for non-HTML which isn't common but is sort-of valid currently.
+            //          3. It means if there's malformed HTML for whatever reason, we're messing with it in a way that may not be predictable.
+            //       There's an alternative way in the JS below but that means the document loads with a bunch of invalid
+            //       attribute values initially which has its own problems.
+            //       Ultimately it would be good to instead be parsing the HTML as we go inside SSTemplateParser and
+            //       only include the preview data comments when it's safe to do so - but that's a lot more work than
+            //       I wanna do for a POC.
+            $html5 = new HTML5();
+            // disable_html_ns must be true or else we get a bunch of extra <br> that weren't there before...
+            // probably that is preventable in other ways but this worked for now.
+            $dom = $html5->loadHTMLFragment($output, ['disable_html_ns' => true]);
+            $nodeStack = [$dom];
+            do {
+                $currNode = array_pop($nodeStack);
+                if ($currNode->hasAttributes()) {
+                    foreach ($currNode->attributes as $attribute) {
+                        $attribute->value = preg_replace(['/<!-- _SS_PREVIEW_DATA_START [^>]+>/', '/<!-- _SS_PREVIEW_DATA_END [^>]+>/'], '', $attribute->value);
+                    }
+                }
+                // The title gets messed up. Just avoid that the hacky way for now.
+                if (strtolower($currNode->nodeName) === 'title') {
+                        $currNode->textContent = preg_replace(['/<!-- _SS_PREVIEW_DATA_START [^>]+>/', '/<!-- _SS_PREVIEW_DATA_END [^>]+>/'], '', $currNode->textContent);
+                }
+                if ($currNode->hasChildNodes()) {
+                    $nodeStack = array_merge($nodeStack, iterator_to_array($currNode->childNodes->getIterator()));
+                }
+            } while (!empty($nodeStack));
+            $output = $dom->ownerDocument->saveHTML($dom);
+
+
+            // When previewing, inject some JavaScript that does two main things:
+            // 1. ~~Remove preview data from inside HTML element's attributes. It shouldn't be there in the first place, this is just a POC hack.~~
+            // 2. Build a map of preview data comments and allow fetching elements that need to be updated for a given field on a given record.
+            // 3. Listens for changes to fields and updates the DOM appropriately
+            // Number 1 will not be used in a real world, because we'd implement the injection in a more robust way to start with.
+            // Numbers 2 and 3 probably belongs in silverstripe/admin or at the very least should be in its own .js file and included with the requirements API.
+            $output = str_replace('</body>', PHP_EOL .
+            <<<'EOL'
+                <script>
+                // Not needed with the HTML parsing above - but that HTML parsing has its downsides too.
+                // // This will remove the preview data from inside HTML attributes.
+                // // It would be better to just not have them there - one way to avoid them being there
+                // // would be to parse the HTML after rendering it which might be a better option
+                // // We probably want smarter behaviour for adding the extra preview data in the first place
+                // // but for the POC this will do.
+                // //
+                // // THEORETICALLY we could use this to update usage of fields in attributes as well
+                // // but at least for the initial launch of the feature that's probably not worth the hassle.
+                // elems = document.getElementsByTagName("*");
+                // for (const el of elems) {
+                //     if (!el.hasAttributes()) {
+                //         continue;
+                //     }
+                //     for (const attr of el.attributes) {
+                //         el.setAttribute(attr.name, el.getAttribute(attr.name).replace(/<!-- _SS_PREVIEW_DATA_START [^>]+>/, '').replace(/<!-- _SS_PREVIEW_DATA_END [^>]+>/, ''));
+                //     }
+                // }
+
+                // This will build a map of all preview data comments so we can easily find relevant bits to update
+                function _SS_PREVIEW_DATA_getKey(data) {
+                    return Object.entries(data).flat().join();
+                }
+                const _SS_PREVIEW_DATA_COMMENTS = {};
+                commentsIterator = document.createTreeWalker(
+                    document,
+                    NodeFilter.SHOW_COMMENT,
+                    null,
+                    false
+                );
+                curnode = null;
+                while (currnode = commentsIterator.nextNode()) {
+                    const startMatches = currnode.textContent?.match(/^\s*_SS_PREVIEW_DATA_START data-class=`(?<classname>[^`]*)` data-id=`(?<id>[^`]*)` data-field=`(?<field>[^`]*)`/);
+                    if (startMatches) {
+                        if (!_SS_PREVIEW_DATA_COMMENTS[_SS_PREVIEW_DATA_getKey(startMatches.groups)]) {
+                            _SS_PREVIEW_DATA_COMMENTS[_SS_PREVIEW_DATA_getKey(startMatches.groups)] = [];
+                        }
+                        _SS_PREVIEW_DATA_COMMENTS[_SS_PREVIEW_DATA_getKey(startMatches.groups)].push(currnode);
+                    }
+                }
+
+                // This function allows us to get all nodes for a given field that need to be updated.
+                // It's a multi-dimensional array.
+                // The top layer represents each instance of the field being rendered.
+                // The second layer is all the elements for that rendering.
+                // e.g. if Content has multiple paragraphs but is only used once in the template, you may get this structure returned:
+                //      [{comment: commentnode, instances: [<p></p>,<p></p>] }]
+                function _SS_PREVIEW_DATA_getElementsToUpdate(classname, id, field) {
+                    const datakey = _SS_PREVIEW_DATA_getKey({classname, id, field});
+                    const comments = _SS_PREVIEW_DATA_COMMENTS[datakey];
+                    if (!comments) {
+                        return [];
+                    }
+                    let sibling = null;
+                    const elems = [];
+                    for (const comment of comments) {
+                        const commentElems = [];
+                        sibling = comment.nextSibling;
+                        // NOTE: They may be nested but that's not in the sibling so this should still work.
+                        while (sibling && (sibling.nodeType !== document.COMMENT_NODE || !sibling.textContent?.match(/^\s*_SS_PREVIEW_DATA_END/))) {
+                            commentElems.push(sibling);
+                            sibling = sibling.nextSibling;
+                        }
+                        elems.push({comment, elements: commentElems});
+                    }
+                    return elems;
+                }
+
+                // This sets up messaging using the PostMessage API so that the CMS can tell us (in the iframe) what has updated.
+                // This should probably be replaced with the Channel Messaging API (see https://javascriptbit.com/transfer-data-between-parent-window-iframe-channel-messaging-api/)
+                // which is more robust (e.g. we know the message comes from the CMS and not from something else in the project) and slightly more secure
+                // But it also requires a bit more boiler plate so I skipped that for this POC.
+                window.addEventListener('message', function(event) {
+                    // @TODO Better handling for the unlikely case where there's other messages passed.
+                    // e.g. one of my react dev tools extensions uses the 'message' event.
+                    if (!event.data.className) {
+                        return;
+                    }
+                    console.log({messageRecieved: event.data}); // debugging
+                    const toUpdate = _SS_PREVIEW_DATA_getElementsToUpdate(event.data.className, event.data.id, event.data.field);
+                    for (const instance of toUpdate) {
+                        // If there's multiple nodes in this instance, get rid of the extras
+                        if (instance.elements.length > 1) {
+                            for (const $i = 1; $i < instance.elements.length; $i++) {
+                                instance.elements[$i].remove();
+                            }
+                        }
+                        // If there's no nodes, the value would have been null before - so we have to add it as a sibling
+                        if (instance.elements.length === 0) {
+                            instance.comment.after(event.data.value);
+                            return;
+                        }
+                        // Replace with the value we set in the CMS.
+                        // @TODO This is pretty garbo lol. We'll want to do a few things:
+                        // 1. probably set up a low-touch endpoint to hydrate the record with the new value and ask it to give us the rendered value back (e.g. so it has the correct casting)
+                        // 2. Handle HTML vs non-HTML values
+                        // ??? probably other improvements.
+                        instance.elements[0].replaceWith(event.data.value);
+                    }
+                });
+                </script>
+            EOL . PHP_EOL . '</body>', $output);
+        }
 
         array_pop(SSTemplateEngine::$topLevel);
 

--- a/src/SSTemplateParser.php
+++ b/src/SSTemplateParser.php
@@ -1136,7 +1136,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     function Injection_STR(&$res, $sub)
     {
-        $res['php'] = '$val .= '. str_replace('$$FINAL', 'getOutputValue', $sub['Lookup']['php'] ?? '') . ';';
+        $res['php'] = '$val .= '. str_replace('$$FINAL', 'getOutputValue1', $sub['Lookup']['php'] ?? '') . ';';
     }
 
     /* DollarMarkedLookup: SimpleInjection */
@@ -1165,7 +1165,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     	$matchrule = "QuotedString"; $result = $this->construct($matchrule, $matchrule, null);
     	$_150 = NULL;
     	do {
-    		$stack[] = $result; $result = $this->construct( $matchrule, "q" ); 
+    		$stack[] = $result; $result = $this->construct( $matchrule, "q" );
     		if (( $subres = $this->rx( '/[\'"]/' ) ) !== FALSE) {
     			$result["text"] .= $subres;
     			$subres = $result; $result = array_pop($stack);
@@ -1175,7 +1175,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$result = array_pop($stack);
     			$_150 = FALSE; break;
     		}
-    		$stack[] = $result; $result = $this->construct( $matchrule, "String" ); 
+    		$stack[] = $result; $result = $this->construct( $matchrule, "String" );
     		if (( $subres = $this->rx( '/ (\\\\\\\\ | \\\\. | [^'.$this->expression($result, $stack, 'q').'\\\\])* /' ) ) !== FALSE) {
     			$result["text"] .= $subres;
     			$subres = $result; $result = array_pop($stack);
@@ -1818,7 +1818,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$pos_251 = $this->pos;
     		$_250 = NULL;
     		do {
-    			$stack[] = $result; $result = $this->construct( $matchrule, "Not" ); 
+    			$stack[] = $result; $result = $this->construct( $matchrule, "Not" );
     			if (( $subres = $this->literal( 'not' ) ) !== FALSE) {
     				$result["text"] .= $subres;
     				$subres = $result; $result = array_pop($stack);
@@ -2211,7 +2211,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		else { $_326 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_326 = FALSE; break; }
-    		$stack[] = $result; $result = $this->construct( $matchrule, "Call" ); 
+    		$stack[] = $result; $result = $this->construct( $matchrule, "Call" );
     		$_322 = NULL;
     		do {
     			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
@@ -2698,7 +2698,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_415 = NULL;
     		do {
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-    			$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" ); 
+    			$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" );
     			$_411 = NULL;
     			do {
     				$_409 = NULL;
@@ -3104,7 +3104,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_543 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-    		$stack[] = $result; $result = $this->construct( $matchrule, "CacheTag" ); 
+    		$stack[] = $result; $result = $this->construct( $matchrule, "CacheTag" );
     		$_496 = NULL;
     		do {
     			$_494 = NULL;
@@ -3163,7 +3163,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_512 = NULL;
     		do {
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-    			$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" ); 
+    			$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" );
     			$_508 = NULL;
     			do {
     				$_506 = NULL;
@@ -3815,7 +3815,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			unset( $pos_624 );
     		}
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-    		$stack[] = $result; $result = $this->construct( $matchrule, "Zap" ); 
+    		$stack[] = $result; $result = $this->construct( $matchrule, "Zap" );
     		if (( $subres = $this->literal( '%>' ) ) !== FALSE) {
     			$result["text"] .= $subres;
     			$subres = $result; $result = array_pop($stack);
@@ -4206,7 +4206,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_682 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-    		$stack[] = $result; $result = $this->construct( $matchrule, "Tag" ); 
+    		$stack[] = $result; $result = $this->construct( $matchrule, "Tag" );
     		$_676 = NULL;
     		do {
     			if (( $subres = $this->literal( 'end_' ) ) !== FALSE) { $result["text"] .= $subres; }

--- a/src/ScopeManager.php
+++ b/src/ScopeManager.php
@@ -7,6 +7,8 @@ use Iterator;
 use LogicException;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\TemplateEngine\Middleware\CMSPreviewMiddleware;
 use SilverStripe\View\SSViewer;
 use SilverStripe\View\TemplateGlobalProvider;
 use SilverStripe\View\ViewLayerData;
@@ -123,6 +125,10 @@ class ScopeManager
      */
     protected array $underlay;
 
+    // @TODO maybe delete.... but maybe this is a way to get the stack of accessed field names.
+    //       That way we can trace MyDate.Nice and know we're looking for the MyDate field for live preview updates.
+    private array $accessStack = [];
+
     public function __construct(
         ?ViewLayerData $item,
         array $overlay = [],
@@ -183,6 +189,7 @@ class ScopeManager
         // $Up and $Top need to restore the overlay from the parent and top-level scope respectively.
         switch ($name) {
             case 'Up':
+                array_pop($this->accessStack);
                 $upIndex = $this->getUpIndex();
                 if ($upIndex === null) {
                     throw new \LogicException('Up called when we\'re already at the top of the scope');
@@ -201,6 +208,7 @@ class ScopeManager
             case 'Top':
                 $overlayIndex = 0; // Top-level scope
                 $this->preserveOverlay = true; // Preserve overlay
+                $this->accessStack = [];
                 list(
                     $this->item,
                     $this->itemIterator,
@@ -211,6 +219,7 @@ class ScopeManager
                 ) = $this->itemStack[0];
                 break;
             default:
+                $this->accessStack[] = $name;
                 $this->preserveOverlay = false;
                 $this->item = $this->getObj($name, $arguments);
                 $this->itemIterator = null;
@@ -259,6 +268,7 @@ class ScopeManager
      */
     public function pushScope(): static
     {
+        // @TODO see how/if this, popstack, and next affect $this->accessStack
         $newLocalIndex = count($this->itemStack ?? []) - 1;
 
         $this->popIndex = $this->itemStack[$newLocalIndex][ScopeManager::POP_INDEX] = $this->localIndex;
@@ -360,6 +370,49 @@ class ScopeManager
     }
 
     /**
+     * Get the value that will be directly rendered in the template.
+     */
+    public function getOutputValue1(string $name, array $arguments): string
+    {
+        $curr = $this->getCurrentItem();
+        $accessName = $name;
+        if ($curr && is_a($curr->ClassName->__toString(), DBField::class, true) && $this->currentIndex > 0) {
+            // @TODO would need to recursively loop 'til we either don't have a DBField or we run out of index
+            //       Even then we're not guaranteed to be at the right place.
+            //       This also doesn't tell us what path took us here, e.g. we know this is Nice, but what field was Nice called on?
+            $curr = $this->itemStack[$this->currentIndex - 1][0];
+            // @TODO test this with some rigor, and apply the same recursion as above.
+            //       Also when we start re-fetching values for correct casting we'll want to append $name, e.g. "MyDate.Nice"
+            $accessName = $this->accessStack[array_key_last($this->accessStack)];
+        }
+        $retval = $this->getObj($name, $arguments);
+        $this->resetLocalScope();
+        // Shove in some comments that tell us what needs to be replaced if we update a field in the CMS.
+        // @TODO still needs some work - e.g:
+        // 1. This gets blasted inside HTML attributes and we have to hack it out
+        // 2. Similar to 1 - because this doesn't know when it's inside an HTML element that hasn't closed yet, forms etc just completely fall over.
+        //    E.g. <img $AttributesHTML /> becomes <img <!-- _SS_PREVIEW_DATA_START etc --><!-- _SS_PREVIEW_DATA_END --> />
+        //    Because the comment is INSIDE the element, it doesn't get treated as a comment. Instead where the comment gets closed that's actually closing the img tag!!
+        // 3. This currently has to be a separate method so it doesn't affect passing values into method calls etc (probably fine)
+        // 4. I don't think this takes explicit method calls into account e.g. $getTitle() or $Title() (probably fine, just document it. We can probably handle it if we want but requires adding args etc to the comment data)
+        // 5. It doesn't understand that $getTitle is the same as $Title... but we can probably handle that on the JS side if we care about it
+        // 6. I'm not sure what to do when $curr is null... for now I just skip it.
+        // 7. Goes hand-in-hand with some of the above, but as a general callout - SOME things just won't be updatable with live preview without re-rendering the whole damn thing.
+        if ($curr !== null && CMSPreviewMiddleware::isCmsPreview()) {
+            // $reflectionData = new ReflectionProperty($retval, 'data');
+            // $obj = $reflectionData->getValue($retval);
+            return sprintf(
+                '<!-- _SS_PREVIEW_DATA_START data-class=`%s` data-id=`%s` data-field=`%s` -->%s<!-- _SS_PREVIEW_DATA_END -->',
+                $curr->ClassName,
+                $curr->ID,
+                $accessName,
+                $retval?->__toString() ?? ''
+            );
+        }
+        return $retval === null ? '' : $retval->__toString();
+    }
+
+    /**
      * Get the value to pass as an argument to a method.
      */
     public function getValueAsArgument(string $name, array $arguments): mixed
@@ -416,6 +469,7 @@ class ScopeManager
      */
     protected function resetLocalScope()
     {
+        // @TODO figure out how to deal with $this->accessStack.... probably keep that in the item stack??
         // Restore previous un-completed lookup chain if set
         $previousLocalState = $this->localStack ? array_pop($this->localStack) : null;
         array_splice($this->itemStack, $this->localIndex + 1, count($this->itemStack ?? []), $previousLocalState);


### PR DESCRIPTION
This POC explores what it would look like to have live updates of the preview panel as content is updated in the CMS. The intention is that templates wouldn't have to be updated at all - instead the template renderer itself marks which DOM nodes relate to which fields.

The general approach is:

- When the CMSPreview get variable is present and the current user has CMS access, the template renderer wraps rendered properties with some sort of identifier.
- In this POC the identifier is an opening and closing HTML comment, since that won't affect what gets rendered in the viewport - though there are problems with the way this POC adds them.
- In the CMS, when a form element gets updated, a message is sent to the preview iframe telling it what updated. Note that this POC only touches input and textarea - select elements etc can be added too. The POC also doesn't touch react which will be its own problem to tackle.
- Inside the iframe, when a message comes through from the CMS, it finds all comments for the updated field and updates the relevant elements.
- The POC ignores casting, so e.g. HTML from the WYSIWYG is encoded and MyDate.Nice will just render the raw date instead of the nice date.

Check out the todo comments for caveats to this approach and shortcuts I've taken.

(making a PR so that even if the branch is deleted, the code can still be found)